### PR TITLE
Add checksums to dataset download records

### DIFF
--- a/src/ai4bmr_datasets/datasets/Cords2024.py
+++ b/src/ai4bmr_datasets/datasets/Cords2024.py
@@ -107,90 +107,112 @@ class Cords2024(BaseIMCDataset):
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/2020115_LC_NSCLC_TMA_86_A.mcd.zip?download=1",
                 file_name="2020115_LC_NSCLC_TMA_86_A.mcd.zip",
+                checksum="7bf62d8252ad15bcf11a34dc64294f72e6618ac30ef8b17f5c39b6bd4760322f",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/2020117_LC_NSCLC_TMA_86_B.mcd.zip?download=1",
                 file_name="2020117_LC_NSCLC_TMA_86_B.mcd.zip",
+                checksum="dbec22705ed3f4811222aa253d173eb167111d85b05bf018608c57557a114a1a",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/2020120_LC_NSCLC_TMA_86_C.mcd.zip?download=1",
                 file_name="2020120_LC_NSCLC_TMA_86_C.mcd.zip",
+                checksum="850db4fd90d0b101667b2595c757bf0a8744bb4234cb637e4d9b84f6d661f6c5",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20201219_LC_NSCLC_TMA_178_A.mcd.zip?download=1",
                 file_name="20201219_LC_NSCLC_TMA_178_A.mcd.zip",
+                checksum="ff97fa311ef948da9f245abdb9bd771616e1996563d5f4a417f2b8d5d8a2de02",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20201222_LC_NSCLC_TMA_178_B_2.mcd.zip?download=1",
                 file_name="20201222_LC_NSCLC_TMA_178_B_2.mcd.zip",
+                checksum="3e41a7e21fb63581609bc4e6962076849a876336405cbd25336213b3ecec1da8",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20201224_LC_NSCLC_TMA_178_C.mcd.zip?download=1",
                 file_name="20201224_LC_NSCLC_TMA_178_C.mcd.zip",
+                checksum="1a2b2ec79488340a0a54a746d1206b61a94bc15182ebcd5fe3b4243fd3ddb523",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20201226_LC_NSCLC_TMA_175_A.mcd.zip?download=1",
                 file_name="20201226_LC_NSCLC_TMA_175_A.mcd.zip",
+                checksum="86f47ecce84c07b2162e682ffe7effd1af703918c0d2fbe5c738a4817e9c3c70",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20201228_LC_NSCLC_TMA_175_B.mcd.zip?download=1",
                 file_name="20201228_LC_NSCLC_TMA_175_B.mcd.zip",
+                checksum="0f02254e85adcac25a1aeb91ac390590dd757037e18799ea4ff664369d023e72",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20210101_LC_NSCLC_TMA_175_C.mcd.zip?download=1",
                 file_name="20210101_LC_NSCLC_TMA_175_C.mcd.zip",
+                checksum="13885eda04dee6d5718a13e940b0af5699af5263812733d14458c7bac7025fde",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20210104_LC_NSCLC_TMA_176_A.mcd.zip?download=1",
                 file_name="20210104_LC_NSCLC_TMA_176_A.mcd.zip",
+                checksum="a88c1f6e1ca563175d5717fbc0bc7670868dd75a4f463a15a759b9e131f60d5c",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20210109_LC_NSCLC_TMA_176_C.mcd.zip?download=1",
                 file_name="20210109_LC_NSCLC_TMA_176_C.mcd.zip",
+                checksum="0219d145bc1bd2e7feee1635de902670cfe6ddfb3bbc4d446168e4594a85920b",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20210112_LC_NSCLC_TMA_176_B.mcd.zip?download=1",
                 file_name="20210112_LC_NSCLC_TMA_176_B.mcd.zip",
+                checksum="2c28c3bb6cb3f6a0958db015d113a4f7452243ce8d885bad46abec197ae4316a",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/2020121_LC_NSCLC_TMA_87_A.mcd.zip?download=1",
                 file_name="2020121_LC_NSCLC_TMA_87_A.mcd.zip",
+                checksum="d333f48269652e0649001ea2a968c5f629c0e215f038b5daca7f10f3c38db770",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20210123_LC_NSCLC_TMA_87_B.mcd.zip?download=1",
                 file_name="20210123_LC_NSCLC_TMA_87_B.mcd.zip",
+                checksum="07fae00241cebbea328f3ac53c2f5466ebc53e62b47ac71ee83aa62a209e9c5c",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20210126_LC_NSCLC_TMA_87_C.mcd.zip?download=1",
                 file_name="20210126_LC_NSCLC_TMA_87_C.mcd.zip",
+                checksum="a0a5cf81dc0ee537d100b66c1dd1fc50ca40fda36eca3e0d67052a72c2748560",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20210129_LC_NSCLC_TMA_88_A.mcd.zip?download=1",
                 file_name="20210129_LC_NSCLC_TMA_88_A.mcd.zip",
+                checksum="9a1af8017ca9e445c815c91be7b5880559eefcfa3f066d8a9e35c5667f2f5d98",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20210129_LC_NSCLC_TMA_88_B.mcd.zip?download=1",
                 file_name="20210129_LC_NSCLC_TMA_88_B.mcd.zip",
+                checksum="7b63619b7608e138567048fbf90bec89f076963730bbf5ac7aa9ff9f0ac96101",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/20210129_LC_NSCLC_TMA_88_C.mcd.zip?download=1",
                 file_name="20210129_LC_NSCLC_TMA_88_C.mcd.zip",
+                checksum="8246ede08b89984caf98a8ce7bd9e97581f7bea81035c66b75b2ef8906ac0986",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/comp_csv_files.zip?download=1",
                 file_name="comp_csv_files.zip",
+                checksum="6a099ad8397f65a054b2cc11355b1554422c483f237d0b57e05342c0606fc693",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/Cell%20masks.zip?download=1",
                 file_name="cell_masks_zenodo.zip",
+                checksum="3dbdfff619b64e67974d7f450c8063aa4992e64594bd292d4c820fb9de4302df",
             ),
             DownloadRecord(
                 url="https://drive.usercontent.google.com/download?id=1wXboMZpkLzk7ZP1Oib1q4NBwvFGK_h7G&confirm=xxx",
                 file_name="cell_masks_google_drive.zip",
+                checksum="03321187e8332b11db0ddba6b9e52b75ed6e0f84a324b3f9311519bff4ca828f",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/7961844/files/SingleCellExperiment%20Objects.zip?download=1",
                 file_name="single_cell_experiment_objects.zip",
+                checksum="14b2ced15f8690f0cd2551fff24a9efe51aa1347eb5768ba06dea7a42f892d30",
             ),
         ]
 

--- a/src/ai4bmr_datasets/datasets/Danenberg.py
+++ b/src/ai4bmr_datasets/datasets/Danenberg.py
@@ -73,10 +73,12 @@ class Danenberg2022(BaseIMCDataset):
             DownloadRecord(
                 url="https://zenodo.org/records/6036188/files/MBTMEStrIMCPublic.zip?download=1",
                 file_name='mbtme_imc_public.zip',
+                checksum="53f03887ebe3c8532f442efb50eb883689c44f67d98cc138501bee8bdfa03666",
             ),
             DownloadRecord(
                 url='https://zenodo.org/records/15615709/files/correctedPublicMasks.zip?download=1',
                 file_name='corrected_public_masks.zip',
+                checksum="0c39d56dd47215d01045e6e73f399d42a1aa42b851d38f29d63211d0e0de631e",
             ),
         ]
 

--- a/src/ai4bmr_datasets/datasets/Jackson2020.py
+++ b/src/ai4bmr_datasets/datasets/Jackson2020.py
@@ -70,22 +70,27 @@ class Jackson2020(BaseIMCDataset):
             DownloadRecord(
                 url="https://zenodo.org/records/4607374/files/OMEandSingleCellMasks.zip?download=1",
                 file_name='ome_and_single_cell_masks.zip',
+                checksum="93708da338fb28a473d209d1cfecbbec03a7aac0b5d53fffcf9bd975177fbab9",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/4607374/files/singlecell_locations.zip?download=1",
                 file_name='single_cell_locations.zip',
+                checksum="8b7a42c373840983dd1c768512dbb2a651a5009e0e2964cd722119be23cedc24",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/4607374/files/singlecell_cluster_labels.zip?download=1",
                 file_name='single_cell_cluster_labels.zip',
+                checksum="c026694a83f28dc5081d7ac05558ea904df072d16ebe73feb3f967ae71ed4984",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/4607374/files/SingleCell_and_Metadata.zip?download=1",
                 file_name='single_cell_and_metadata.zip',
+                checksum="04c5ffb7037105b829ea8d413e844f415d166a58ae85e3668a2c0b46bc37db42",
             ),
             DownloadRecord(
                 url="https://zenodo.org/records/4607374/files/TumorStroma_masks.zip?download=1",
                 file_name='tumor_stroma_masks.zip',
+                checksum="268d266d5cd958707ddd1480620fc8c5100a2dc37b969bd98f47dba316d7abb8",
             ),
         ]
 

--- a/src/ai4bmr_datasets/datasets/Keren2018.py
+++ b/src/ai4bmr_datasets/datasets/Keren2018.py
@@ -55,10 +55,12 @@ class Keren2018(BaseIMCDataset):
             DownloadRecord(
                 url="https://www.dropbox.com/scl/fo/wgytss4wnubn05hnp69jg/ADMhoNHgJTpxAbEE9PQn1zY?rlkey=g79sa4b50hkx2nyjksgmqzrhl&e=1&st=nsaw5cbr&dl=1",
                 file_name="tnbc.zip",
+                checksum="aa884867979b8eb8c74e7d64b446571d762abd1eeb0d6425a1036c974c4ba649",
             ),
             DownloadRecord(
                 url="https://www.angelolab.com/_files/archives/302cbc_72cbeda2c99342c0a1b3940d6bac144f.zip?dn=TNBC_shareCellData.zip",
                 file_name="tnbc_processed_data.zip",
+                checksum="5ccb0a52ca8686490ce8c9a36900eefa77f2942a456bfe856f4e4aeb32bbe633",
             ),
             DownloadRecord(
                 url="https://ars.els-cdn.com/content/image/1-s2.0-S0092867418311000-mmc1.xlsx",


### PR DESCRIPTION
## Summary
- add recorded SHA-256 checksums for Cords2024 download artifacts
- include checksum validation for Danenberg2022, Jackson2020, and Keren2018 downloads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69253066356483258c5a0639eb1f7487)